### PR TITLE
Added len check to prevent stack smashing + increased buffer size

### DIFF
--- a/src/LibTeleinfo.cpp
+++ b/src/LibTeleinfo.cpp
@@ -656,6 +656,10 @@ ValueList * TInfo::checkLine(char * pline)
 
   len = strlen(pline); 
 
+  // prevent stack smashing
+  if(len > TINFO_BUFSIZE)
+    return NULL; 
+
   // a line should be at least 7 Char
   // 2 Label + Space + 1 etiquette + space + checksum + \r
   if ( len < 7 )

--- a/src/LibTeleinfo.h
+++ b/src/LibTeleinfo.h
@@ -106,7 +106,7 @@ enum _State_e {
 
 // Local buffer for one line of teleinfo 
 // maximum size, I think it should be enought
-#define TINFO_BUFSIZE  64
+#define TINFO_BUFSIZE  128
 
 // Teleinfo start and end of frame characters
 #define TINFO_STX 0x02


### PR DESCRIPTION
Dans certaines conditions, la fonction checkline provoquait une erreur de stack smashing. En vérifiant bien que la longueur de la ligne ne dépasse pas celle du buffer, plus de problème.

J'ai également augmenté la taille du buffer à 128 octets, car pour certains compteurs, 64 octets ne suffisent pas.