### PR TITLE
Ajout gestion d'erreur et traitement du caratere EOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Cette oeuvre est mise à disposition selon les termes de la Licence Creative Com
 
 Si vous êtes une entreprise et que vous souhaitez participer car vous utilisez cette librairie dans du hardware (box, automate, ...), vous pouvez toujours m'envoyer un exemplaire de votre fabrication, c'est toujours sympa de voir ce qui est fait avec ce code ;-)
 
+# Addon
+
+Ajout des compteurs d'erreurs, et du traitement du caracteres EOT d'interruption de trames
+
 # Divers
 
 Vous pouvez aller voir les nouveautés et autres projets sur [blog][7] 

--- a/library.json
+++ b/library.json
@@ -10,7 +10,8 @@
   },
   "authors":
   {
-    "name": "François-Régis Colin"
+    "name": "Charles-Henri Hallard",
+    "url": "http://hallard.me"
   },
   "frameworks": "arduino",
   "platforms": "*"  

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "LibTeleinfo",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "keywords": "teleinfo, french, meter, power, erdf, linky, tic",
   "description": "Decoder for Teleinfo (aka TIC) from French smart power meters",
   "repository":
@@ -11,7 +11,8 @@
   "authors":
   {
     "name": "Charles-Henri Hallard",
-    "url": "http://hallard.me"
+    "url": "http://hallard.me",
+    "name": "François-Régis Colin",
   },
   "frameworks": "arduino",
   "platforms": "*"  

--- a/library.json
+++ b/library.json
@@ -10,7 +10,7 @@
   },
   "authors":
   {
-    "name": "François-Régis Colin",
+    "name": "François-Régis Colin"
   },
   "frameworks": "arduino",
   "platforms": "*"  

--- a/library.json
+++ b/library.json
@@ -10,8 +10,6 @@
   },
   "authors":
   {
-    "name": "Charles-Henri Hallard",
-    "url": "http://hallard.me",
     "name": "François-Régis Colin",
   },
   "frameworks": "arduino",

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=LibTeleinfo
-version=1.1.4
-author=Charles-Henri Hallard <hallard.me>
-maintainer=Charles-Henri Hallard <community.hallard.me>
+version=1.1.5
+author=François-Régis Colin
+maintainer=François-Régis Colin
 sentence=Decoder for Teleinfo (aka TIC) from French smart power meters
 paragraph=This is a generic Teleinfo (aka TIC) French Meter Measure Library, it can be used on Arduino, Particle, ESP8266, Raspberry PI or anywhere you can do Cpp coding.
 category=Communication
-url=https://github.com/hallard/LibTeleinfo
+url=https://github.com/FrColin/LibTeleinfo.git
 architectures=*

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=LibTeleinfo
 version=1.1.5
-author=François-Régis Colin
-maintainer=François-Régis Colin
+author=Charles-Henri Hallard <hallard.me>
+maintainer=Charles-Henri Hallard <community.hallard.me>
 sentence=Decoder for Teleinfo (aka TIC) from French smart power meters
 paragraph=This is a generic Teleinfo (aka TIC) French Meter Measure Library, it can be used on Arduino, Particle, ESP8266, Raspberry PI or anywhere you can do Cpp coding.
 category=Communication
-url=https://github.com/FrColin/LibTeleinfo.git
+url=https://github.com/hallard/LibTeleinfo
 architectures=*

--- a/src/LibTeleinfo.cpp
+++ b/src/LibTeleinfo.cpp
@@ -906,10 +906,6 @@ ValueList * TInfo::checkLine(char * pline)
           else
           {
             checksumerror++;
-            char str_checksumerror[64];
-            uint8_t upd_flags  = TINFO_FLAGS_UPDATED;
-            itoa(checksumerror,str_checksumerror,10);
-            addCustomValue("checksumerror", str_checksumerror, &upd_flags);
             TI_Debugf(PSTR("LibTeleinfo::checkLine Err checksum 0x%02X != 0x%02X"), calc_checksum, checksum);
           }
         }

--- a/src/LibTeleinfo.h
+++ b/src/LibTeleinfo.h
@@ -144,10 +144,10 @@ class TInfo
     boolean       listDelete();
     unsigned char calcChecksum(char *etiquette, char *valeur, char *horodate=NULL) ;
     
-    int         getChecksumErrorCount() {return checksumerror;};
-    int         getFrameSizeErrorCount(){return framesizeerror;};
-    int         getFrameFormatErrorCount(){return frameformaterror;};
-    int         getFrameInterruptedCount(){return frameinterrupted;};
+    uint32_t      getChecksumErrorCount() {return checksumerror;};
+    uint32_t      getFrameSizeErrorCount(){return framesizeerror;};
+    uint32_t      getFrameFormatErrorCount(){return frameformaterror;};
+    uint32_t      getFrameInterruptedCount(){return frameinterrupted;};
 
   private:
     void          clearBuffer();
@@ -171,10 +171,10 @@ class TInfo
     void      (*_fn_new_frame)(ValueList * valueslist);
     void      (*_fn_updated_frame)(ValueList * valueslist);
 
-    int       checksumerror;
-    int       frameformaterror;
-    int       framesizeerror;
-    int       frameinterrupted;
+    uint32_t  checksumerror;
+    uint32_t  frameformaterror;
+    uint32_t  framesizeerror;
+    uint32_t  frameinterrupted;
 
     //volatile uint8_t *dcport;
     //uint8_t dcpinmask;

--- a/src/LibTeleinfo.h
+++ b/src/LibTeleinfo.h
@@ -119,6 +119,7 @@ enum _State_e {
 #define TINFO_HT  0x09
 #define TINFO_SGR '\n' // start of group
 #define TINFO_EGR '\r' // End of group
+#define TINFO_EOT 0x04 // frame interrupt
 
 typedef void (*_fn_ADPS) (uint8_t);
 typedef void (*_fn_data) (ValueList *, uint8_t);
@@ -164,6 +165,11 @@ class TInfo
     void      (*_fn_data)(ValueList * valueslist, uint8_t state);
     void      (*_fn_new_frame)(ValueList * valueslist);
     void      (*_fn_updated_frame)(ValueList * valueslist);
+
+    int       badchecksum;
+    int       frameformaterror;
+    int       framesizeerror;
+    int       frameinterrupted;
 
     //volatile uint8_t *dcport;
     //uint8_t dcpinmask;

--- a/src/LibTeleinfo.h
+++ b/src/LibTeleinfo.h
@@ -143,6 +143,11 @@ class TInfo
     char *        valueGet_P(const char * name, char * value);
     boolean       listDelete();
     unsigned char calcChecksum(char *etiquette, char *valeur, char *horodate=NULL) ;
+    
+    int         getChecksumErrorCount() {return checksumerror;};
+    int         getFrameSizeErrorCount(){return framesizeerror;};
+    int         getFrameFormatErrorCount(){return frameformaterror;};
+    int         getFrameInterruptedCount(){return frameinterrupted;};
 
   private:
     void          clearBuffer();
@@ -166,7 +171,7 @@ class TInfo
     void      (*_fn_new_frame)(ValueList * valueslist);
     void      (*_fn_updated_frame)(ValueList * valueslist);
 
-    int       badchecksum;
+    int       checksumerror;
     int       frameformaterror;
     int       framesizeerror;
     int       frameinterrupted;


### PR DESCRIPTION
le comptage d'erreur permet de mesurer la fiabilité de la transmission TIC
le caractère EOT est parfois transmis pour interrompre la trame en cours.
Enedis-NOI-CPT_02E.pdf ( Page : 19 )