### PR TITLE
Update LibTeleinfo.cpp

### DIFF
--- a/src/LibTeleinfo.cpp
+++ b/src/LibTeleinfo.cpp
@@ -448,7 +448,13 @@ Input   : Pointer to the label name
           pointer to the value where we fill data 
 Output  : pointer to the value where we filled data NULL is not found
 ====================================================================== */
-char * TInfo::valueGet(char * name, char * value)
+String TInfo::valueGet(String name)
+{
+  char *Cname = const_cast<char*>(name.c_str());
+  return String(TInfo::valueGet(Cname));
+}
+
+char * TInfo::valueGet(char * name)
 {
   // Get our linked list 
   ValueList * me = &_valueslist;
@@ -469,10 +475,8 @@ char * TInfo::valueGet(char * name, char * value)
         if (me->value) {
           // Check back checksum
           if (me->checksum == calcChecksum(me->name, me->value)) {
-            // copy to dest buffer
-            uint8_t lgvalue = strlen(me->value);
-            strncpy(value, me->value , lgvalue + 1 );
-            return ( value );
+            // return value
+            return ( me->value );
           }
         }
       }

--- a/src/LibTeleinfo.h
+++ b/src/LibTeleinfo.h
@@ -140,7 +140,8 @@ class TInfo
     ValueList *   addCustomValue(char * name, char * value, uint8_t * flags);
     ValueList *   getList(void);
     uint8_t       valuesDump(void);
-    char *        valueGet(char * name, char * value);
+    char *        valueGet(char * name);
+    String        valueGet(String name);
     char *        valueGet_P(const char * name, char * value);
     bool          listDelete();
     void          clearStats();


### PR DESCRIPTION
Repair valueget function, add String handle to work easyly with ESP32

dans mon code qui complète une page html enregistrée sur le système de fichier de l'esp j'ai des étiquettes 
notammment pour l'affichage du compteur notés par exemple dans le code entre deux symboles ^

```
<tr><td>Rouge<td>^C1_EASF06^ Wh<td>^C1_EASF05^ Wh
<tr><td>Puiss.Act.<td colspan=2>^C1_SINSTS^ VA
```


ainsi je peux facilement mettre à jour l'affichage désiré

et dans mon sketch ça  ressemble à ça : (fonction appelée pour remplacer les étiquettes par une valeur String)

```
if (Etiq.startsWith("C1_")) {  //étiquettes C1_
    if (Etiq == "C1_RELAIS") { //affichage personnalisé pour la valeur de relais en binaire
      return String(strtol(tinfo.valueGet((char *)"RELAIS"), NULL, 16), BIN);
    }
    if (Etiq == "C1_HPBLEU") { //pour exemple 
      return tinfo.valueGet("EASF02") ;
    }
    return tinfo.valueGet(Etiq.substring(3)); //recherche et affichage des autres étiquettes compteur en enlevant "C1_" en début de chaine
  }

```

n'ayant pas réussi à faire fonctionner la fonction TInfo::valueGet(), je l'ai modifiée car de plus elle provoquait de plantages comme j'ai tenté de m'en servir.
Ayant retiré un memcopy et trois variables, je pense que c'est une amélioration si tant est qu'elle fonctionnait.

